### PR TITLE
Add artifact attestations to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   goreleaser:
@@ -22,6 +24,7 @@ jobs:
           go-version: '1.23'
 
       - name: Run GoReleaser
+        id: goreleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
@@ -29,3 +32,8 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: 'dist/*'


### PR DESCRIPTION
## Summary
Add build provenance attestations to release artifacts for enhanced security and verification.

## Changes
- Add `id-token` and `attestations` permissions to release workflow
- Add attestation generation step using `actions/attest-build-provenance@v2`
- Provides cryptographic verification of all build artifacts

This allows users to verify the authenticity and provenance of downloaded binaries.