### PR TITLE
Add Homebrew tap support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,6 +36,19 @@ changelog:
       - '^docs:'
       - '^test:'
 
+brews:
+  - name: lts
+    repository:
+      owner: benfdking
+      name: lts
+      token: "{{ .Env.GITHUB_TOKEN }}"
+    folder: Formula
+    homepage: "https://github.com/benfdking/lts"
+    description: "Convert natural language to shell commands using AI"
+    license: "MIT"
+    install: |
+      bin.install "lts"
+
 release:
   github:
     owner: benfdking

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ A simple CLI tool that converts natural language into shell commands using AI.
 
 ## Installation
 
+### Homebrew (macOS/Linux)
+
+```bash
+brew tap benfdking/lts
+brew install lts
+```
+
 ### Download pre-built binaries
 
 Download the latest release from the [releases page](https://github.com/benfdking/lts/releases).


### PR DESCRIPTION
## Summary
Add Homebrew tap support for easy installation on macOS and Linux.

## Changes
- Configure GoReleaser to generate Homebrew formula in `Formula/` directory
- Update README with Homebrew installation instructions

## Installation
After merging and releasing, users can install with:
```bash
brew tap benfdking/lts
brew install lts
```