### PR TITLE
Fix GoReleaser config: change 'folder' to 'directory'

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,7 +42,7 @@ brews:
       owner: benfdking
       name: lts
       token: "{{ .Env.GITHUB_TOKEN }}"
-    folder: Formula
+    directory: Formula
     homepage: "https://github.com/benfdking/lts"
     description: "Convert natural language to shell commands using AI"
     license: "MIT"


### PR DESCRIPTION
## Summary
Fix GoReleaser configuration error where `folder` field is not recognized.

## Changes
- Change `folder: Formula` to `directory: Formula` in brews configuration
- The `folder` field was deprecated and replaced with `directory` in GoReleaser v2

This fixes the build error:
```
yaml: unmarshal errors:
  line 45: field folder not found in type config.Homebrew
```