### PR TITLE
Add init command for interactive configuration

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+}
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize LTS configuration",
+	Long:  `Interactive setup to create ~/.lts.yaml configuration file.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		reader := bufio.NewReader(os.Stdin)
+
+		fmt.Println("Welcome to LTS configuration!")
+		fmt.Println()
+
+		// Check if config already exists
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to get home directory: %w", err)
+		}
+		configPath := filepath.Join(homeDir, ".lts.yaml")
+
+		if _, err := os.Stat(configPath); err == nil {
+			fmt.Printf("Config file already exists at %s\n", configPath)
+			fmt.Print("Overwrite? (y/N): ")
+			response, _ := reader.ReadString('\n')
+			response = strings.TrimSpace(strings.ToLower(response))
+			if response != "y" && response != "yes" {
+				fmt.Println("Configuration cancelled.")
+				return nil
+			}
+		}
+
+		// Provider selection
+		fmt.Println("Select your LLM provider:")
+		fmt.Println("1. Claude Code (Anthropic API)")
+		fmt.Println("2. Ollama (Local)")
+		fmt.Print("Choice (1-2): ")
+
+		choice, _ := reader.ReadString('\n')
+		choice = strings.TrimSpace(choice)
+
+		var configData map[string]interface{}
+
+		switch choice {
+		case "1":
+			configData = map[string]interface{}{
+				"llm_provider": "claude-code",
+			}
+			fmt.Println()
+			fmt.Println("Selected: Claude Code")
+			fmt.Println("Remember to set your ANTHROPIC_API_KEY environment variable:")
+			fmt.Println("  export ANTHROPIC_API_KEY=your_key_here")
+
+		case "2":
+			configData = map[string]interface{}{
+				"llm_provider": "ollama",
+			}
+
+			fmt.Println()
+			fmt.Println("Selected: Ollama")
+			fmt.Println()
+
+			// Ollama URL
+			fmt.Print("Ollama URL (press Enter for default: http://localhost:11434): ")
+			url, _ := reader.ReadString('\n')
+			url = strings.TrimSpace(url)
+
+			// Ollama Model
+			fmt.Print("Model name (press Enter for default: llama3.2): ")
+			model, _ := reader.ReadString('\n')
+			model = strings.TrimSpace(model)
+
+			ollamaConfig := make(map[string]string)
+			if url != "" {
+				ollamaConfig["url"] = url
+			}
+			if model != "" {
+				ollamaConfig["model"] = model
+			}
+
+			if len(ollamaConfig) > 0 {
+				configData["ollama"] = ollamaConfig
+			}
+
+		default:
+			return fmt.Errorf("invalid choice: %s", choice)
+		}
+
+		// Write config file
+		yamlData, err := yaml.Marshal(configData)
+		if err != nil {
+			return fmt.Errorf("failed to marshal config: %w", err)
+		}
+
+		if err := os.WriteFile(configPath, yamlData, 0600); err != nil {
+			return fmt.Errorf("failed to write config file: %w", err)
+		}
+
+		fmt.Println()
+		fmt.Printf("Configuration saved to %s\n", configPath)
+		fmt.Println("You're all set! Try running: lts list all files in current directory")
+
+		return nil
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,10 @@ var rootCmd = &cobra.Command{
 		// Load config
 		cfg, err := config.Load()
 		if err != nil {
-			return fmt.Errorf("failed to load config: %w", err)
+			fmt.Fprintf(os.Stderr, "Error: %v\n\n", err)
+			fmt.Fprintf(os.Stderr, "It looks like you haven't set up LTS yet.\n")
+			fmt.Fprintf(os.Stderr, "Run 'lts init' to create your configuration file.\n")
+			os.Exit(1)
 		}
 
 		// Create LLM provider


### PR DESCRIPTION
## Summary
Add `lts init` command to interactively create the `~/.lts.yaml` configuration file.

## Changes
- Add interactive `lts init` command with provider selection (Claude Code or Ollama)
- For Ollama, prompt for custom URL and model (both optional with defaults)
- Update root command to suggest running `lts init` when config file is missing
- Config file created with secure permissions (0600)

## Example Usage
```bash
$ lts init
Welcome to LTS configuration!

Select your LLM provider:
1. Claude Code (Anthropic API)
2. Ollama (Local)
Choice (1-2): 2

Selected: Ollama

Ollama URL (press Enter for default: http://localhost:11434): 
Model name (press Enter for default: llama3.2): 

Configuration saved to /Users/username/.lts.yaml
You're all set! Try running: lts list all files in current directory
```