### PR TITLE
Replace YAML configuration with JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,31 @@ go build -o lts
 
 ## Configuration
 
-Create a configuration file at `~/.lts.yaml`:
+Create a configuration file at `~/.lts.json`:
 
 ### Claude (Anthropic API)
 
-```yaml
-llm_provider: claude-code
+```json
+{
+  "llm_provider": "claude-code"
+}
 ```
 
 Set your API key:
 ```bash
 export ANTHROPIC_API_KEY=your_key_here
+```
+
+### Ollama (Local LLM)
+
+```json
+{
+  "llm_provider": "ollama",
+  "ollama": {
+    "url": "http://localhost:11434",
+    "model": "llama3.2"
+  }
+}
 ```
 
 ## Usage

--- a/config/config.go
+++ b/config/config.go
@@ -1,21 +1,20 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
-
-	"gopkg.in/yaml.v3"
 )
 
 type Config struct {
-	LLMProvider  string        `yaml:"llm_provider"`
-	OllamaConfig *OllamaConfig `yaml:"ollama,omitempty"`
+	LLMProvider  string        `json:"llm_provider"`
+	OllamaConfig *OllamaConfig `json:"ollama,omitempty"`
 }
 
 type OllamaConfig struct {
-	URL   string `yaml:"url"`
-	Model string `yaml:"model"`
+	URL   string `json:"url"`
+	Model string `json:"model"`
 }
 
 func Load() (*Config, error) {
@@ -24,14 +23,14 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("failed to get home directory: %w", err)
 	}
 
-	configPath := filepath.Join(homeDir, ".lts.yaml")
+	configPath := filepath.Join(homeDir, ".lts.json")
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file %s: %w", configPath, err)
 	}
 
 	var cfg Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/benfdking/lts
 
 go 1.25.1
 
+require github.com/spf13/cobra v1.10.1
+
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.10.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,5 +8,4 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Summary
- Replaced goyaml dependency with standard library JSON parsing
- Changed configuration file from `~/.lts.yaml` to `~/.lts.json`
- Updated documentation with JSON configuration examples

## Changes
- Removed `gopkg.in/yaml.v3` dependency from go.mod
- Updated `config/config.go` to use `encoding/json` instead of yaml
- Changed struct tags from `yaml:` to `json:`
- Updated README.md with JSON format configuration examples for both Claude and Ollama

## Benefits
- Fewer external dependencies
- Using Go standard library for configuration parsing
- JSON is a more universal format

## Test plan
- [x] Build project successfully
- [x] Run go mod tidy to clean dependencies
- [ ] Test with Claude provider configuration
- [ ] Test with Ollama provider configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)