### PR TITLE
Optimize binary size with goreleaser ldflags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,11 @@ builds:
       - arm64
     binary: lts
     main: ./main.go
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+    flags:
+      - -trimpath
 
 archives:
   - format: tar.gz


### PR DESCRIPTION
## Summary
- Add `-s -w` ldflags to strip debug info and symbol tables
- Add `-trimpath` flag to remove absolute file paths from binaries
- Add version injection support with `-X main.version={{.Version}}`

## Impact
Expected binary size reduction of 20-30% across all platforms (linux, darwin, windows) and architectures (amd64, arm64).

## Test plan
- [ ] Verify goreleaser builds successfully with new flags
- [ ] Compare binary sizes before/after on sample platform
- [ ] Confirm binaries still function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)