### PR TITLE
Fix goreleaser deprecation warnings

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,8 @@ builds:
       - -trimpath
 
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
@@ -32,7 +33,8 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 
 changelog:
   sort: asc
@@ -41,7 +43,7 @@ changelog:
       - '^docs:'
       - '^test:'
 
-brews:
+homebrew:
   - name: lts
     repository:
       owner: benfdking


### PR DESCRIPTION
## Summary
- Replace `archives.format` with `archives.formats`
- Replace `format_overrides.format` with `format_overrides.formats`
- Replace `brews` with `homebrew`

## Impact
Eliminates deprecation warnings from goreleaser v2 while maintaining identical functionality.

## Test plan
- [ ] Verify goreleaser builds successfully without deprecation warnings
- [ ] Confirm brew formula still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)