### PR TITLE
Add OpenAI provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple CLI tool that converts natural language into shell commands using AI.
 ## Features
 
 - Convert English descriptions into executable shell commands
-- Support for multiple LLM providers (Claude, Ollama)
+- Support for multiple LLM providers (Claude, OpenAI, Ollama)
 - Built with Go using Cobra for a robust CLI experience
 - Shell autocompletion support (bash, zsh, fish, powershell)
 - Cross-platform releases (Linux, macOS, Windows)
@@ -46,6 +46,19 @@ Create a configuration file at `~/.lts.json`:
 Set your API key:
 ```bash
 export ANTHROPIC_API_KEY=your_key_here
+```
+
+### OpenAI
+
+```json
+{
+  "llm_provider": "openai"
+}
+```
+
+Set your API key:
+```bash
+export OPENAI_API_KEY=your_key_here
 ```
 
 ### Ollama (Local LLM)

--- a/llm/openai.go
+++ b/llm/openai.go
@@ -1,0 +1,93 @@
+package llm
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+type OpenAIProvider struct{}
+
+type openaiRequest struct {
+	Model    string          `json:"model"`
+	Messages []openaiMessage `json:"messages"`
+}
+
+type openaiMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openaiResponse struct {
+	Choices []openaiChoice `json:"choices"`
+}
+
+type openaiChoice struct {
+	Message openaiMessage `json:"message"`
+}
+
+func (o *OpenAIProvider) Translate(prompt string) (string, error) {
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		return "", fmt.Errorf("OPENAI_API_KEY environment variable not set")
+	}
+
+	systemPrompt := "You are a CLI command translator. Convert natural language requests into shell commands. Return ONLY the command, nothing else. No explanations, no markdown, just the raw command."
+
+	reqBody := openaiRequest{
+		Model: "gpt-4",
+		Messages: []openaiMessage{
+			{
+				Role:    "system",
+				Content: systemPrompt,
+			},
+			{
+				Role:    "user",
+				Content: prompt,
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var openaiResp openaiResponse
+	if err := json.Unmarshal(body, &openaiResp); err != nil {
+		return "", fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if len(openaiResp.Choices) == 0 {
+		return "", fmt.Errorf("no choices in response")
+	}
+
+	return openaiResp.Choices[0].Message.Content, nil
+}

--- a/llm/provider.go
+++ b/llm/provider.go
@@ -14,6 +14,8 @@ func NewProvider(cfg *config.Config) (Provider, error) {
 	switch cfg.LLMProvider {
 	case "claude-code":
 		return &ClaudeCodeProvider{}, nil
+	case "openai":
+		return &OpenAIProvider{}, nil
 	case "ollama":
 		provider := &OllamaProvider{}
 		if cfg.OllamaConfig != nil {


### PR DESCRIPTION
## Summary
- Added OpenAI as a new LLM provider option
- Uses OpenAI API with `OPENAI_API_KEY` environment variable
- Supports GPT-4 model for command translation

## Changes
- **New file**: `llm/openai.go` - OpenAI provider implementation
- **Modified**: `llm/provider.go` - Added `openai` case to provider factory
- **Modified**: `README.md` - Updated documentation with OpenAI configuration

## Test plan
- [ ] Test openai provider with OPENAI_API_KEY set
- [ ] Verify GPT-4 command translation works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)