### PR TITLE
Fix claude CLI invocation by removing --prompt flag

### DIFF
--- a/llm/claude_code.go
+++ b/llm/claude_code.go
@@ -18,7 +18,7 @@ func (c *ClaudeCodeProvider) Translate(prompt string) (string, error) {
 	fullPrompt := fmt.Sprintf("%s\n\nRequest: %s", systemPrompt, prompt)
 
 	// Use claude CLI which handles authentication automatically
-	cmd := exec.Command("claude", "--prompt", fullPrompt)
+	cmd := exec.Command("claude", fullPrompt)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("failed to run claude CLI: %w\nOutput: %s", err, string(output))


### PR DESCRIPTION
## Summary
- Remove the `--prompt` flag from claude CLI invocation
- The claude CLI doesn't support this flag, causing commands to fail
- Pass the prompt directly as an argument instead

## Test plan
- [x] Built and tested with `./lts "git add all"` 
- [x] Successfully translates natural language to shell commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)