### PR TITLE
Add configurable model support for Anthropic and OpenAI providers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,12 +10,22 @@ import (
 // Config for lts. The general structure of it is the provider which matches
 // the then following name of the corresponding config block.
 type Config struct {
-	Provider string  `json:"provider"`
-	Ollama   *Ollama `json:"ollama,omitempty"`
+	Provider  string     `json:"provider"`
+	Ollama    *Ollama    `json:"ollama,omitempty"`
+	Anthropic *Anthropic `json:"anthropic,omitempty"`
+	OpenAI    *OpenAI    `json:"openai,omitempty"`
 }
 
 type Ollama struct {
 	URL   string `json:"url"`
+	Model string `json:"model"`
+}
+
+type Anthropic struct {
+	Model string `json:"model"`
+}
+
+type OpenAI struct {
 	Model string `json:"model"`
 }
 

--- a/llm/anthropic.go
+++ b/llm/anthropic.go
@@ -9,7 +9,9 @@ import (
 	"os"
 )
 
-type AnthropicProvider struct{}
+type AnthropicProvider struct {
+	Model string
+}
 
 type anthropicRequest struct {
 	Model     string    `json:"model"`
@@ -39,8 +41,13 @@ func (a *AnthropicProvider) Translate(prompt string) (string, error) {
 
 	systemPrompt := "You are a CLI command translator. Convert natural language requests into shell commands. Return ONLY the command, nothing else. No explanations, no markdown, just the raw command."
 
+	model := a.Model
+	if model == "" {
+		model = "claude-3-5-sonnet-20241022"
+	}
+
 	reqBody := anthropicRequest{
-		Model:     "claude-3-5-sonnet-20241022",
+		Model:     model,
 		MaxTokens: 1024,
 		Messages: []message{
 			{

--- a/llm/openai.go
+++ b/llm/openai.go
@@ -9,7 +9,9 @@ import (
 	"os"
 )
 
-type OpenAIProvider struct{}
+type OpenAIProvider struct {
+	Model string
+}
 
 type openaiRequest struct {
 	Model    string          `json:"model"`
@@ -37,8 +39,13 @@ func (o *OpenAIProvider) Translate(prompt string) (string, error) {
 
 	systemPrompt := "You are a CLI command translator. Convert natural language requests into shell commands. Return ONLY the command, nothing else. No explanations, no markdown, just the raw command."
 
+	model := o.Model
+	if model == "" {
+		model = "gpt-4"
+	}
+
 	reqBody := openaiRequest{
-		Model: "gpt-4",
+		Model: model,
 		Messages: []openaiMessage{
 			{
 				Role:    "system",


### PR DESCRIPTION
## Summary
- Added `Model` field to `AnthropicProvider` and `OpenAIProvider` structs
- Updated config to include `Anthropic` and `OpenAI` configuration blocks with model selection
- Maintains backward compatibility with default models (`claude-3-5-sonnet-20241022` for Anthropic, `gpt-4` for OpenAI)

## Test plan
- [ ] Verify Anthropic provider uses custom model when specified in `.lts.json`
- [ ] Verify OpenAI provider uses custom model when specified in `.lts.json`
- [ ] Verify both providers fall back to defaults when model is not specified
- [ ] Ensure config parsing works correctly with the new optional fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)