### PR TITLE
Fix GoReleaser v2 compatibility issues

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,7 +43,7 @@ changelog:
       - '^docs:'
       - '^test:'
 
-homebrew:
+brews:
   - name: lts
     repository:
       owner: benfdking
@@ -60,6 +60,8 @@ release:
   github:
     owner: benfdking
     name: lts
+  extra_files:
+    - glob: ./install.sh
 
 # Universal installation script
 announce:
@@ -69,8 +71,4 @@ announce:
 blobs:
   - provider: s3
     bucket: "{{ .Env.AWS_BUCKET }}"
-    folder: "{{ .ProjectName }}/{{ .Version }}"
-
-# Alternative: Include install.sh in release assets
-extra_files:
-  - glob: ./install.sh
+    directory: "{{ .ProjectName }}/{{ .Version }}"


### PR DESCRIPTION
## Summary
- Renamed `homebrew` to `brews` to match GoReleaser v2 API
- Changed `folder` to `directory` in blobs configuration
- Moved `extra_files` into the `release` section where it belongs

## Test plan
- [ ] Verify GoReleaser build succeeds without unmarshal errors
- [ ] Confirm Homebrew tap generation still works
- [ ] Validate install.sh is included in release assets
- [ ] Test S3 blob upload uses correct directory path

🤖 Generated with [Claude Code](https://claude.com/claude-code)